### PR TITLE
Fixed bug for copying rh.curv.pial not lh.curv.pial

### DIFF
--- a/FreeSurfer/scripts/FreeSurferHiresPial.sh
+++ b/FreeSurfer/scripts/FreeSurferHiresPial.sh
@@ -137,6 +137,6 @@ cp $SubjectDIR/$SubjectID/surf/lh.area.pial.T2.two $SubjectDIR/$SubjectID/surf/l
 cp $SubjectDIR/$SubjectID/surf/rh.area.pial.T2.two $SubjectDIR/$SubjectID/surf/rh.area.pial
 
 cp $SubjectDIR/$SubjectID/surf/lh.curv.pial.T2.two $SubjectDIR/$SubjectID/surf/lh.curv.pial
-cp $SubjectDIR/$SubjectID/surf/rh.curv.pial.T2.two $SubjectDIR/$SubjectID/surf/lh.curv.pial
+cp $SubjectDIR/$SubjectID/surf/rh.curv.pial.T2.two $SubjectDIR/$SubjectID/surf/rh.curv.pial
 
 echo -e "\n END: FreeSurferHighResPial"


### PR DESCRIPTION
In the FreeSurfer Pipeline, the last copy command should copy rh.curv.pial instead of lh.curv.pial. 